### PR TITLE
Add new pac archive format implementation which covers most files in the majority of modern arcsys games

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcsys"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,7 +12,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 flate2 = "1.0"
 binrw = "0.13"
-bitflags = "2.2"
+bitflags = "2.4"
 encoding_rs = "0.8.33"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,19 @@ nom = "7.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 flate2 = "1.0"
-binrw = "0.12"
+binrw = "0.13"
 bitflags = "2.2"
+encoding_rs = "0.8.33"
 
 [dev-dependencies]
+hex = "0.4.3"
 clap = { version = "4.2", features = ["derive"] }
 anyhow = "1.0"
 rayon = "1.7"
 serde_json = "1.0"
 smallvec = "1.10"
+# for test folders
+walkdir = "2.4.0"
 
 [[example]]
 name = "cli"

--- a/src/bbcf/hip.rs
+++ b/src/bbcf/hip.rs
@@ -10,7 +10,7 @@ use byteorder::{WriteBytesExt, LE};
 use nom::{
     bytes::complete::{tag, take},
     error::ErrorKind,
-    number::complete::{le_u32, le_u8, le_u16},
+    number::complete::{le_u16, le_u32, le_u8},
     IResult,
 };
 use serde::{Deserialize, Serialize};

--- a/src/bbcf/hpl.rs
+++ b/src/bbcf/hpl.rs
@@ -6,7 +6,7 @@ use nom::bytes::complete::tag;
 use nom::number::complete::le_u16;
 use nom::number::complete::le_u32;
 use nom::IResult;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 static MAGIC_HPL: &[u8] = b"HPAL";
 
@@ -62,10 +62,9 @@ fn parse_palette(i: &[u8], size: u32) -> IResult<&[u8], Vec<RGBAColor>> {
     nom::multi::count(helpers::parse_bgra, size as usize)(i)
 }
 
-
 impl BBCFHpl {
     pub fn to_bytes(&self) -> Vec<u8> {
-        use byteorder::{LE, WriteBytesExt};
+        use byteorder::{WriteBytesExt, LE};
         use std::io::Write;
 
         // BBCF palette file structure
@@ -83,8 +82,12 @@ impl BBCFHpl {
 
         final_bytes.write_all(MAGIC_HPL).unwrap();
         final_bytes.write_u32::<LE>(self.version).unwrap();
-        final_bytes.write_u32::<LE>((HEADER_SIZE + (self.palette.len() * 0x4)) as u32).unwrap();
-        final_bytes.write_u32::<LE>(self.palette.len() as u32).unwrap();
+        final_bytes
+            .write_u32::<LE>((HEADER_SIZE + (self.palette.len() * 0x4)) as u32)
+            .unwrap();
+        final_bytes
+            .write_u32::<LE>(self.palette.len() as u32)
+            .unwrap();
 
         // unknown data
         final_bytes.write_u32::<LE>(self.unknown_data.0).unwrap();
@@ -96,7 +99,9 @@ impl BBCFHpl {
         final_bytes.write_u32::<LE>(0x0).unwrap();
 
         // write palette
-        self.palette.iter().for_each(|p| final_bytes.extend(p.to_bgra_slice()));
+        self.palette
+            .iter()
+            .for_each(|p| final_bytes.extend(p.to_bgra_slice()));
 
         final_bytes
     }

--- a/src/bbcf/mod.rs
+++ b/src/bbcf/mod.rs
@@ -1,3 +1,3 @@
 pub mod hip;
-pub mod pac;
 pub mod hpl;
+pub mod pac;

--- a/src/bbcf/pac.rs
+++ b/src/bbcf/pac.rs
@@ -11,6 +11,7 @@ use nom::{bytes::complete::take, combinator, number::complete::le_u32, IResult};
 
 /// Archive format for BBCF
 #[derive(Serialize, Deserialize)]
+#[deprecated(note = "`arcsys::pac::Pac` replaces this")]
 pub struct BBCFPac {
     pub unknown: u32,
     pub files: Vec<BBCFPacEntry>,
@@ -50,6 +51,7 @@ impl crate::traits::Pac for BBCFPac {
 
 /// A contained file in a [`BBCFPac`] archive.
 #[derive(Serialize, Deserialize)]
+#[deprecated(note = "`arcsys::pac::Pac` replaces this")]
 pub struct BBCFPacEntry {
     /// The file ID
     pub id: u32,

--- a/src/ggacpr/mod.rs
+++ b/src/ggacpr/mod.rs
@@ -15,8 +15,7 @@ pub mod replay {
     }
 
     #[binread]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct ReplayTime {
         pub year: u16,
         pub month: u8,
@@ -28,8 +27,7 @@ pub mod replay {
 
     #[binread]
     #[br(repr = u8)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub enum Character {
         Sol = 1,
         Ky,
@@ -60,8 +58,7 @@ pub mod replay {
 
     #[binread]
     #[br(repr = u8)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub enum MatchType {
         Single = 1,
         Team,
@@ -69,8 +66,7 @@ pub mod replay {
 
     #[binread]
     #[br(repr = u8)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub enum GameVersion {
         PlusR = 0,
         AccentCore,
@@ -78,8 +74,7 @@ pub mod replay {
 
     #[binread]
     #[br(repr = u8)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub enum MatchResult {
         P1Winner = 1,
         P2Winner,
@@ -89,8 +84,7 @@ pub mod replay {
     #[binread]
     // MAGIC signature is this literal on all ACPR replays after Dec. 2021
     #[br(little, magic = b"GGR\x02\x51\xAD\xEE\x77\x45\xD7\x48\xCD")]
-    #[derive(Debug, Clone)]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct AcprReplay {
         #[br(temp)]
         _metadata_size: u16,

--- a/src/ggst/jonbin.rs
+++ b/src/ggst/jonbin.rs
@@ -105,7 +105,7 @@ fn parse_editor_data(i: &[u8]) -> IResult<&[u8], &[u8]> {
     Ok((i, bytes))
 }
 
-fn parse_box(i: &[u8],) -> IResult<&[u8], HitBox> {
+fn parse_box(i: &[u8]) -> IResult<&[u8], HitBox> {
     let (i, kind) = le_u32(i)?;
     let (i, rect) = parse_rect(i)?;
 

--- a/src/ggst/pac.rs
+++ b/src/ggst/pac.rs
@@ -1,10 +1,14 @@
-use crate::{helpers, traits::{Pac, Rebuild}};
+use crate::{
+    helpers,
+    traits::{Pac, Rebuild},
+};
 
 use binrw::{binread, io::SeekFrom, NullString};
 
 #[binread]
 #[br(little, magic = b"FPAC")]
 #[derive(Clone, Debug)]
+#[deprecated(note = "`arcsys::pac::Pac` replaces this")]
 pub struct GGSTPac {
     #[br(temp)]
     data_start: u32,
@@ -78,8 +82,8 @@ impl Rebuild for GGSTPac {
 }
 
 fn rebuild_pac_impl(pac: &GGSTPac) -> Vec<u8> {
-    use std::io::Write;
     use byteorder::{WriteBytesExt, LE};
+    use std::io::Write;
 
     let mut pac_file: Vec<u8> = Vec::new();
 

--- a/src/ggxrd/mod.rs
+++ b/src/ggxrd/mod.rs
@@ -1,2 +1,1 @@
 //pub mod jonbin;
-pub mod pac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,17 +10,77 @@ pub use crate::traits::{ParseFromBytes, Rebuild};
 
 /// Blazblue Centralfiction
 pub mod bbcf;
-/// Dragon Ball Z: Extreme Butoden and One Piece: Great Pirate Colosseum
-pub mod dbzop;
 /// Guilty Gear XX Accent Core +R
 pub mod ggacpr;
 /// Guilty Gear STRIVE
 pub mod ggst;
+/// PAC archive format found in most arcsys games.
+pub mod pac;
 
 pub use error::Error;
 pub use helpers::{arcsys_filename_hash, IndexedImage, RGBAColor};
 
 #[cfg(test)]
 mod tests {
+    use std::env;
+    use std::io::{Cursor, Read};
+    use std::path::PathBuf;
 
+    use binrw::BinRead;
+    use walkdir::WalkDir;
+
+    #[test]
+    fn test_pac() {
+        let pac_path = PathBuf::from(
+            env::var("ARCSYS_PACS").expect("Must have ARCSYS_PACS env variable set!"),
+        );
+        let paths = WalkDir::new(pac_path);
+
+        for entry in paths.into_iter().map(|x| x.unwrap()) {
+            let path = entry.path();
+
+            // skip TXAC
+            if path.to_string_lossy().contains("txac") {
+                println!("skipping TXAC: {path:?}");
+                continue;
+            }
+
+            if path.is_dir() {
+                continue;
+            }
+
+            println!("parsing: {path:?}");
+
+            let mut pac_bytes = Vec::new();
+            std::fs::File::open(path)
+                .unwrap()
+                .read_to_end(&mut pac_bytes)
+                .unwrap();
+
+            let pac = crate::pac::Pac::read(&mut Cursor::new(&pac_bytes)).unwrap();
+
+            println!("info: {:?}", pac.pac_style);
+
+            let rebuilt_bytes = pac.to_bytes();
+
+            if rebuilt_bytes != pac_bytes {
+                let file_name = path.file_stem().unwrap().to_string_lossy();
+
+                let _ = std::fs::create_dir("TEST_OUTPUT");
+
+                std::fs::write(
+                    format!("./TEST_OUTPUT/{file_name}_REBUILT.pac"),
+                    rebuilt_bytes,
+                )
+                .unwrap();
+                std::fs::write(format!("./TEST_OUTPUT/{file_name}_ORIGINAL.pac"), pac_bytes)
+                    .unwrap();
+
+                // if file_name.contains("bg_halloween_4") {
+                //     pac.entries.iter().for_each(|x| println!("{:?}", x.name))
+                // }
+                panic!("rebuilt bytes dont match for {}", path.display());
+            }
+        }
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,11 @@
-use crate::{helpers::{pad_to_nearest, pad_to_nearest_with_excess, RGBAColor}, Error};
+use crate::{
+    helpers::{pad_to_nearest, pad_to_nearest_with_excess, RGBAColor},
+    Error,
+};
 
 /// Trait that parses a type from some binary data.
 /// This is a wrapper over [`BinRead`] which accepts all types that implement `AsRef<[u8]>`
-pub trait ParseFromBytes: Sized  {
+pub trait ParseFromBytes: Sized {
     /// Parse a type from a slice of bytes
     fn parse<R: AsRef<[u8]>>(bytes: &R) -> Result<Self, Error>;
 }


### PR DESCRIPTION
Current caveats: there is still no support for the `PATH_CUT` pac style hash function, and TXAC is still an unresearched format