### PR TITLE
Support for ggst 5.00 jonbins

### DIFF
--- a/src/ggst/jonbin.rs
+++ b/src/ggst/jonbin.rs
@@ -44,13 +44,12 @@ pub struct HitBox {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rect {
-    x_offset: f32,
-    y_offset: f32,
-    width: f32,
-    height: f32,
+    pub x_offset: f32,
+    pub y_offset: f32,
+    pub width: f32,
+    pub height: f32,
 }
 
-const BOX_LAYER_COUNT: usize = 0x2C;
 fn parse_jonbin_impl(i: &[u8]) -> IResult<&[u8], GGSTJonBin> {
     let (i, _) = tag(GGSTJonBin::MAGIC_JONB)(i)?;
 
@@ -69,8 +68,12 @@ fn parse_jonbin_impl(i: &[u8]) -> IResult<&[u8], GGSTJonBin> {
     // dbg!(editor_data_count);
     // dbg!(hurtbox_count);
     // dbg!(hitbox_count);
+    let box_layer_count = match version {
+        ..=277 => 0x2C, // versions prior to 277 have not been observed, but we shall assume they are the same as 277 itself
+        278.. => 0x2D, // battle version 5.00 as the earliest
+    };
 
-    let (i, mut box_layer_sizes) = count(le_u16, BOX_LAYER_COUNT)(i)?;
+    let (i, mut box_layer_sizes) = count(le_u16, box_layer_count)(i)?;
 
     let (i, editor_data) = count(parse_editor_data, editor_data_count as usize)(i)?;
 

--- a/src/pac.rs
+++ b/src/pac.rs
@@ -231,7 +231,7 @@ struct InternalPac {
     file_count: u32,
     #[br(map = |x: u32| PacStyle::from_bits_retain(x))]
     pub pac_style: PacStyle,
-    #[br(temp, align_after = 0x10, dbg)]
+    #[br(temp, align_after = 0x10)]
     string_size: u32,
     #[br(args {
         count: file_count as usize,


### PR DESCRIPTION
The latest ggst [patch 2.00](https://www.guiltygear.com/ggst/en/news/post-2851/) (battle version 5.00)  introduced a new hitbox layer which now fails to parse with the current code that does not expect it. This PR adjusts the expected amount of layers based on jonbin version (versions up to 277 inclusive having 44 layers, version 278+ having 45).

This PR also makes `ggst::jonbin::Rect` fields public, so that I can use them as a library consumer, and cleans up minor debug leftover.

I have checked that all the currently present pacs in strive archive get parsed without error, and spot-checked that they are consistent with what I see in game.